### PR TITLE
Remove AWS version lock

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,6 @@ terraform {
     aws = {
       configuration_aliases = [aws.identity, aws.route53]
       source                = "hashicorp/aws"
-      version               = "~> 4.0"
     }
   }
 }


### PR DESCRIPTION
This PR removes the `~> 4.0` AWS provider version constraint. 

I'm not sure what a good target is now, but in our project we use `5.20.0`. We've been successfully using this module for a couple weeks without issue.

