### PR TITLE
Bump Terraform AWS provider from version 4 to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ module "domain_identity" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws.identity"></a> [aws.identity](#provider\_aws.identity) | ~> 4.0 |
-| <a name="provider_aws.route53"></a> [aws.route53](#provider\_aws.route53) | ~> 4.0 |
+| <a name="provider_aws.identity"></a> [aws.identity](#provider\_aws.identity) | ~> 5.0 |
+| <a name="provider_aws.route53"></a> [aws.route53](#provider\_aws.route53) | ~> 5.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
     aws = {
       configuration_aliases = [aws.identity, aws.route53]
       source                = "hashicorp/aws"
-      version               = "~> 4.0"
+      version               = "~> 5.0"
     }
   }
 }


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0

Ref:
- https://trello.com/c/MIAiwlJ4/25-update-terraform-modules-to-support-aws-v5-providers